### PR TITLE
Be able to set array.rates without historicalRates

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -156,7 +156,6 @@ class Configuration implements ConfigurationInterface
                                 ->variableNode('historicalRates')
                                     ->treatFalseLike(null)
                                     ->treatTrueLike(null)
-                                    ->isRequired()
                                     ->cannotBeEmpty()
                                     ->validate()
                                         ->ifTrue(function($config) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -140,6 +140,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     ],
                 ],
             ]],
+            [[
+                'array' => [
+                    'rates' => [
+                        'EUR/USD' => 1.1,
+                        'EUR/GBP' => 1.5,
+                    ],
+                ],
+            ]],
         ];
     }
 
@@ -165,7 +173,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             [['array' => null]],
             [['array' => []]],
             [['array' => ['EUR/GBP' => 1.5]]],
-            [['array' => ['rates' => ['EUR/GBP' => 1.5]]]],
             [['array' => ['rates' => [['EUR/GBP' => 0]]]]],
             [['array' => ['rates' => [['any' => 'any']]]]],
             [['array' => ['rates' => [['2017-01-01' => 'any']]]]],


### PR DESCRIPTION
Change the TreeBuilder config in order to allow to use array.rate without array.historicalRates