### PR TITLE
Fix setting PSR-16 cache provider

### DIFF
--- a/DependencyInjection/FlorianvSwapExtension.php
+++ b/DependencyInjection/FlorianvSwapExtension.php
@@ -102,7 +102,7 @@ class FlorianvSwapExtension extends Extension
                 throw new InvalidArgumentException("Cache class $class does not exist.");
             }
 
-            $definition = new Definition($class, $arguments);
+            $definition = new Definition('Symfony\Component\Cache\Psr16Cache', [new Definition($class, $arguments)]);
             $definition->setPublic(false);
             $container->setDefinition($id, $definition);
         } elseif ($container->hasDefinition($type)) {

--- a/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
+++ b/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
@@ -172,12 +172,13 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
 
         /** @var Definition */
         $cacheDefinition = $this->container->getDefinition('florianv_swap.cache');
-        $this->assertEquals($cacheDefinition->getClass(), $class);
+        $this->assertEquals($cacheDefinition->getClass(), 'Symfony\Component\Cache\Psr16Cache');
+        $this->assertEquals($cacheDefinition->getArgument(0)->getClass(), $class);
         $this->assertFalse($cacheDefinition->isPublic());
 
-        $this->assertEquals($config, $cacheDefinition->getArguments());
+        $this->assertEquals($config, $cacheDefinition->getArgument(0)->getArguments());
 
         $cache = $this->container->get('florianv_swap.cache');
-        $this->assertInstanceOf($class, $cache);
+        $this->assertInstanceOf('Symfony\Component\Cache\Psr16Cache', $cache);
     }
 }


### PR DESCRIPTION
Fixes this error when setting the cache provider:
```
Argument 1 passed to Swap\Builder::useSimpleCache() must be an instance of Psr\SimpleCache\CacheInterface, instance of Symfony\Component\Cache\Adapter\ArrayAdapter given
```
Related: https://github.com/florianv/exchanger/commit/2e94456e357ab3025426e1d8e68aa9ae1e5bd0a2 and https://github.com/florianv/symfony-swap/pull/29