### PR TITLE
Update to symfony 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 7.1
-        - php: 7.2
+        - php: 7.2.5
         - php: 7.3
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 7.2.5
+        - php: 7.1
+        - php: 7.2
         - php: 7.3
 
 cache:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,8 +26,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('florianv_swap');
-        $rootNode = $treeBuilder->getRootNode();
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('florianv_swap');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('florianv_swap');
+        }
 
         $rootNode
             ->fixXmlConfig('provider')
@@ -194,10 +199,17 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
+
     private function createSimpleProviderNode($name)
     {
-        $treeBuilder = new TreeBuilder($name);
-        $node = $treeBuilder->getRootNode();
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder($name);
+            $node = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $node = $treeBuilder->root($name);
+        }
+
         $node
             ->children()
                 ->integerNode('priority')->defaultValue(0)->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,12 +27,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('florianv_swap');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            $rootNode = $treeBuilder->root('florianv_swap');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->fixXmlConfig('provider')
@@ -202,12 +197,7 @@ class Configuration implements ConfigurationInterface
     private function createSimpleProviderNode($name)
     {
         $treeBuilder = new TreeBuilder($name);
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->getRootNode();
-        } else {
-            $node = $treeBuilder->root($name);
-        }
+        $node = $treeBuilder->getRootNode();
         $node
             ->children()
                 ->integerNode('priority')->defaultValue(0)->end()

--- a/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
+++ b/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
@@ -15,7 +15,7 @@ use Florianv\SwapBundle\DependencyInjection\FlorianvSwapExtension;
 use Swap\Builder;
 use Swap\Swap;
 use Symfony\Component\Cache\Adapter;
-use Symfony\Component\Cache\Traits\ApcuTrait;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -123,7 +123,7 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testApcuCache()
     {
-        if (!ApcuTrait::isSupported()) {
+        if (!ApcuAdapter::isSupported()) {
             $this->markTestSkipped('APCU is not enabled');
         }
 
@@ -160,6 +160,7 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
      *
      * @param $class
      * @param $config
+     * @throws \Exception
      */
     private function assertCache($class, $config)
     {

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": "^7.2.5",
-        "symfony/framework-bundle": "~5.0",
+        "php": "^5.6|^7.0",
+        "symfony/framework-bundle": "~3.0|~4.0|~5.0",
         "florianv/swap": "^4.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/message": "^1.7",
-        "symfony/cache": "~5.0",
+        "symfony/cache": "~3.0|~4.0|~5.0",
         "phpunit/phpunit": "~5.0",
         "nyholm/psr7": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": "^5.6|^7.0",
-        "symfony/framework-bundle": "~3.0 || ~4.0",
+        "php": "^7.2.5",
+        "symfony/framework-bundle": "~5.0",
         "florianv/swap": "^4.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/message": "^1.7",
-        "symfony/cache": "~3.0|~4.0",
+        "symfony/cache": "~5.0",
         "phpunit/phpunit": "~5.0",
         "nyholm/psr7": "^1.1"
     },


### PR DESCRIPTION
This PR is based on @jkhaled PR but for 4.1.0 (his work is for 3.2.0).

Symfony package require ~5.0
PHP minimal version up to 7.2.5 because of symfony/framework-bundle:~5.0 dependencies.