### PR TITLE
Php 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
         - php: 7.1
         - php: 7.2
         - php: 7.3
+        - php: 7.4
+        - php: 8.0
 
 cache:
   directories:

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,6 +12,7 @@
 namespace Florianv\SwapBundle\Tests\DependencyInjection;
 
 use Florianv\SwapBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Config\Definition\Processor;
 
@@ -20,25 +21,25 @@ use Symfony\Component\Config\Definition\Processor;
  * @package Tests\DependencyInjection
  * @author  Etienne Dauvergne <contact@ekyna.com>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
-     * @var Configuration
+     * @var ?Configuration
      */
     private $configuration;
 
     /**
-     * @var Processor
+     * @var ?Processor
      */
     private $processor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configuration = new Configuration();
         $this->processor = new Processor();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->configuration = null;
         $this->processor = null;
@@ -49,13 +50,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider provideValidProvidersConfigs
      */
-    public function testValidProvidersConfig(array $providers)
+    public function testValidProvidersConfig(array $providers): void
     {
-        $this->processor->processConfiguration($this->configuration, [
+        $configuration = $this->processor->processConfiguration($this->configuration, [
             'florianv_swap' => [
                 'providers' => $providers,
             ],
         ]);
+
+        self::assertTrue(is_array($configuration));
+
     }
 
     /**
@@ -63,7 +67,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider provideInvalidProvidersConfigs
      */
-    public function testInvalidProvidersConfig(array $providers)
+    public function testInvalidProvidersConfig(array $providers): void
     {
         $this->expectException(Exception::class);
 
@@ -79,14 +83,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider provideValidCacheConfigs
      */
-    public function testValidCacheConfig(array $cache)
+    public function testValidCacheConfig(array $cache): void
     {
-        $this->processor->processConfiguration($this->configuration, [
+        $configuration = $this->processor->processConfiguration($this->configuration, [
             'florianv_swap' => [
                 'providers' => ['fixer' => ['access_key' => 'YOUR_KEY']],
                 'cache'     => $cache,
             ],
         ]);
+
+        self::assertTrue(is_array($configuration));
     }
 
     /**
@@ -94,7 +100,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider provideInvalidCacheConfigs
      */
-    public function testInvalidCacheConfig(array $cache)
+    public function testInvalidCacheConfig(array $cache): void
     {
         $this->expectException(Exception::class);
 
@@ -106,7 +112,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function provideValidProvidersConfigs()
+    public function provideValidProvidersConfigs(): array
     {
         return [
             [['central_bank_of_czech_republic' => null]],
@@ -153,7 +159,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function provideInvalidProvidersConfigs()
+    public function provideInvalidProvidersConfigs(): array
     {
         return [
             [[]],
@@ -184,7 +190,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function provideValidCacheConfigs()
+    public function provideValidCacheConfigs(): array
     {
         return [
             [[]],
@@ -192,7 +198,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function provideInvalidCacheConfigs()
+    public function provideInvalidCacheConfigs(): array
     {
         return [
             [['any' => 'any']],

--- a/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
+++ b/Tests/DependencyInjection/FlorianvSwapExtensionTest.php
@@ -12,16 +12,18 @@
 namespace Florianv\SwapBundle\Tests\DependencyInjection;
 
 use Florianv\SwapBundle\DependencyInjection\FlorianvSwapExtension;
+use PHPUnit\Framework\TestCase;
 use Swap\Builder;
 use Swap\Swap;
 use Symfony\Component\Cache\Adapter;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
+class FlorianvSwapExtensionTest extends TestCase
 {
     /**
      * @var ContainerBuilder
@@ -33,54 +35,69 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->extension = new FlorianvSwapExtension();
     }
 
-    public function testBuilderService()
+    /**
+     * @throws \Exception
+     */
+    public function testBuilderService(): void
     {
         $this->buildContainer();
 
-        /** @var \Swap\Builder $builder */
+        /** @var Builder $builder */
         $builder = $this->container->get('florianv_swap.builder');
 
-        $this->assertInstanceOf(Builder::class, $builder);
+        self::assertInstanceOf(Builder::class, $builder);
     }
 
-    public function testSwapService()
+    /**
+     * @throws \Exception
+     */
+    public function testSwapService(): void
     {
         $this->buildContainer();
 
-        /** @var \Swap\Swap $swap */
+        /** @var Swap $swap */
         $swap = $this->container->get('florianv_swap.swap');
-        $this->assertInstanceOf(Swap::class, $swap);
+        self::assertInstanceOf(Swap::class, $swap);
     }
 
-    public function testNoProvider()
+    public function testNoProvider(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->buildContainer([], []);
     }
 
-    public function testFixerProvider()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testFixerProvider(): void
     {
         $this->buildContainer(['fixer' => ['access_key' => 'test']]);
     }
 
-    public function testForgeProvider()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testForgeProvider(): void
     {
         $this->buildContainer(['forge' => ['api_key' => 'test']]);
     }
 
-    public function testXchangeApiProvider()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testXchangeApiProvider(): void
     {
         $this->buildContainer(['xchangeapi' => ['api-key' => 'test']]);
     }
 
-    public function testProviderPriorities()
+    public function testProviderPriorities(): void
     {
         $this->buildContainer([
             'fixer' => ['access_key' => 'YOUR_KEY'],
@@ -97,39 +114,45 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
         $calls = $swap->getMethodCalls();
 
         // European Central Bank first
-        $this->assertEquals($calls[0][0], 'add');
-        $this->assertEquals($calls[0][1][0], 'european_central_bank');
-        $this->assertEquals($calls[0][1][1], []);
+        self::assertEquals('add', $calls[0][0]);
+        self::assertEquals('european_central_bank', $calls[0][1][0]);
+        self::assertEquals([], $calls[0][1][1]);
 
         // Forge second
-        $this->assertEquals($calls[1][0], 'add');
-        $this->assertEquals($calls[1][1][0], 'forge');
-        $this->assertEquals($calls[1][1][1], ['api_key' => 'test']);
+        self::assertEquals('add', $calls[1][0]);
+        self::assertEquals('forge', $calls[1][1][0]);
+        self::assertEquals(['api_key' => 'test'], $calls[1][1][1]);
 
         // Fixer third
-        $this->assertEquals($calls[2][0], 'add');
-        $this->assertEquals($calls[2][1][0], 'fixer');
-        $this->assertEquals($calls[2][1][1], ['access_key' => 'YOUR_KEY', 'enterprise' => false]);
+        self::assertEquals('add', $calls[2][0]);
+        self::assertEquals('fixer', $calls[2][1][0]);
+        self::assertEquals(['access_key' => 'YOUR_KEY', 'enterprise' => false], $calls[2][1][1]);
     }
 
-    public function testCacheMissTtl()
+    public function testCacheMissTtl(): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
         $this->buildContainer(['fixer' => ['access_key' => 'YOUR_KEY']], ['ttl' => null]);
     }
 
-    public function testArrayCache()
+    /**
+     * @throws \Exception
+     */
+    public function testArrayCache(): void
     {
         $this->buildContainer(['fixer' => ['access_key' => 'YOUR_KEY']], ['type' => 'array', 'ttl' => 60]);
 
         $this->assertCache(Adapter\ArrayAdapter::class, [60]);
     }
 
-    public function testApcuCache()
+    /**
+     * @throws \Exception
+     */
+    public function testApcuCache(): void
     {
         if (!ApcuAdapter::isSupported()) {
-            $this->markTestSkipped('APCU is not enabled');
+            self::markTestSkipped('APCU is not enabled');
         }
 
         $this->buildContainer(['fixer' => ['access_key' => 'YOUR_KEY']], ['type' => 'apcu']);
@@ -137,7 +160,10 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertCache(Adapter\ApcuAdapter::class, ['swap', 3600]);
     }
 
-    public function testFilesystemCache()
+    /**
+     * @throws \Exception
+     */
+    public function testFilesystemCache(): void
     {
         $this->buildContainer(['fixer' => ['access_key' => 'YOUR_KEY']], ['type' => 'filesystem']);
 
@@ -150,7 +176,7 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
      * @param array $providers
      * @param array $cache
      */
-    private function buildContainer(array $providers = ['fixer' => ['access_key' => 'test']], array $cache = [])
+    private function buildContainer(array $providers = ['fixer' => ['access_key' => 'test']], array $cache = []): void
     {
         $this->extension->load([
             'florianv_swap' => [
@@ -167,24 +193,25 @@ class FlorianvSwapExtensionTest extends \PHPUnit_Framework_TestCase
      * @param $config
      * @throws \Exception
      */
-    private function assertCache($class, $config)
+    private function assertCache($class, $config): void
     {
         $swap = $this->container->getDefinition('florianv_swap.builder');
         $calls = $swap->getMethodCalls();
-        $this->assertEquals($calls[0][0], 'useSimpleCache');
+        self::assertEquals('useSimpleCache', $calls[0][0]);
+
         /** @var Reference $cacheReference */
         $cacheReference = $calls[0][1][0];
-        $this->assertEquals('florianv_swap.cache', (string)$cacheReference);
+        self::assertEquals('florianv_swap.cache', (string)$cacheReference);
 
         /** @var Definition */
         $cacheDefinition = $this->container->getDefinition('florianv_swap.cache');
-        $this->assertEquals($cacheDefinition->getClass(), 'Symfony\Component\Cache\Psr16Cache');
-        $this->assertEquals($cacheDefinition->getArgument(0)->getClass(), $class);
-        $this->assertFalse($cacheDefinition->isPublic());
+        self::assertEquals(Psr16Cache::class, $cacheDefinition->getClass());
+        self::assertEquals($class, $cacheDefinition->getArgument(0)->getClass());
+        self::assertFalse($cacheDefinition->isPublic());
 
-        $this->assertEquals($config, $cacheDefinition->getArgument(0)->getArguments());
+        self::assertEquals($config, $cacheDefinition->getArgument(0)->getArguments());
 
         $cache = $this->container->get('florianv_swap.cache');
-        $this->assertInstanceOf('Symfony\Component\Cache\Psr16Cache', $cache);
+        self::assertInstanceOf(Psr16Cache::class, $cache);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6|^7.0|^8.0",
         "symfony/framework-bundle": "~3.0|~4.0|~5.0",
         "florianv/swap": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": "^5.6|^7.0|^8.0",
+        "php": "^7.1.3|^8.0",
         "symfony/framework-bundle": "~3.0|~4.0|~5.0",
         "florianv/swap": "^4.0"
     },
@@ -24,7 +24,7 @@
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/message": "^1.7",
         "symfony/cache": "~3.0|~4.0|~5.0",
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~5.7|~6.0|~7.0|~8.0|~9.0",
         "nyholm/psr7": "^1.1"
     },
     "suggest": {


### PR DESCRIPTION
Add compatibility with PHP 8.0
Drop compatibility with php < 7.1.3 (like florianv/swap ~4.0)
Add compatibility with phpunit from 5.7 to 9.x