### PR TITLE
Renamed config variable from `rates` to `latestRates`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -184,7 +184,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('array')
                             ->children()
                                 ->integerNode('priority')->defaultValue(0)->end()
-                                ->variableNode('rates')
+                                ->variableNode('latestRates')
                                     ->treatFalseLike(null)
                                     ->treatTrueLike(null)
                                     ->isRequired()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -135,7 +135,7 @@ class ConfigurationTest extends TestCase
             [['xchangeapi' => ['api-key' => 'any']]],
             [[
                 'array' => [
-                    'rates' => [
+                    'latestRateslatestRates' => [
                         'EUR/USD' => 1.1,
                         'EUR/GBP' => 1.5,
                     ],
@@ -151,7 +151,7 @@ class ConfigurationTest extends TestCase
             ]],
             [[
                 'array' => [
-                    'rates' => [
+                    'latestRates' => [
                         'EUR/USD' => 1.1,
                         'EUR/GBP' => 1.5,
                     ],
@@ -184,10 +184,10 @@ class ConfigurationTest extends TestCase
             [['array' => null]],
             [['array' => []]],
             [['array' => ['EUR/GBP' => 1.5]]],
-            [['array' => ['rates' => [['EUR/GBP' => 0]]]]],
-            [['array' => ['rates' => [['any' => 'any']]]]],
-            [['array' => ['rates' => [['2017-01-01' => 'any']]]]],
-            [['array' => ['rates' => [['2017-01-01' => ['any' => 'any']]]]]],
+            [['array' => ['latestRates' => [['EUR/GBP' => 0]]]]],
+            [['array' => ['latestRates' => [['any' => 'any']]]]],
+            [['array' => ['latestRates' => [['2017-01-01' => 'any']]]]],
+            [['array' => ['latestRates' => [['2017-01-01' => ['any' => 'any']]]]]],
         ];
     }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -135,7 +135,7 @@ class ConfigurationTest extends TestCase
             [['xchangeapi' => ['api-key' => 'any']]],
             [[
                 'array' => [
-                    'latestRateslatestRates' => [
+                    'latestRates' => [
                         'EUR/USD' => 1.1,
                         'EUR/GBP' => 1.5,
                     ],


### PR DESCRIPTION
Renamed config variable from `rates` to `latestRates`, as that's the variable used in the code.