### PR TITLE
Fix config example for `array` provider

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -92,7 +92,7 @@ florianv_swap:
         xchangeapi:                        # xChangeApi.com
            api-key: secret    
         array:
-            rates:
+            latestRates:
                     'EUR/GBP': 1.5
                     'EUR/USD': 1.1
             historicalRates:


### PR DESCRIPTION
This PR follows #49 with and fixes a config example for the `array` provider in documentation.