### PR TITLE
Add Symfony 7 support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (method_exists(TreeBuilder::class, 'getRootNode')) {
             $treeBuilder = new TreeBuilder('florianv_swap');

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     },
     "require": {
         "php": "^7.1.3|^8.0",
-        "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0",
+        "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0|~7.0",
         "florianv/swap": "^4.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0",
         "php-http/message": "^1.7",
-        "symfony/cache": "~3.0|~4.0|~5.0|~6.0",
+        "symfony/cache": "~3.0|~4.0|~5.0|~6.0|~7.0",
         "phpunit/phpunit": "~5.7|~6.0|~7.0|~8.0|~9.0",
         "nyholm/psr7": "^1.1"
     },


### PR DESCRIPTION
- Updated composer.json to add support for Symfony 7 
- Added a return type to `getConfigTreeBuilder()` now that the parent method explicitly defines the return type of '`TreeBuilder`'