### PR TITLE
Improve README, documentation, and discoverability

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 - 2026 Florian Voutzinos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,210 @@
-# <img src="https://s3.amazonaws.com/swap.assets/swap_logo.png" height="30px" width="30px"/> Symfony Swap
+# Symfony Swap
 
 [![Tests](https://github.com/florianv/symfony-swap/actions/workflows/tests.yml/badge.svg)](https://github.com/florianv/symfony-swap/actions/workflows/tests.yml)
 [![Psalm](https://github.com/florianv/symfony-swap/actions/workflows/psalm.yml/badge.svg)](https://github.com/florianv/symfony-swap/actions/workflows/psalm.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/florianv/swap-bundle.svg?style=flat-square)](https://packagist.org/packages/florianv/swap-bundle)
 [![Version](http://img.shields.io/packagist/v/florianv/swap-bundle.svg?style=flat-square)](https://packagist.org/packages/florianv/swap-bundle)
 
-Swap allows you to retrieve currency exchange rates from various services such as **[Fixer](https://fixer.io/)**, **[Currency Data](https://currencylayer.com)**
-or **[Exchange Rates Data](https://exchangeratesapi.io)** and optionally cache the results.
+> _Drop-in Symfony bundle for currency conversion. Multi-provider exchange rates with fallback, caching, and Symfony Cache integration. Maintained since 2014._
 
-## QuickStart
+**Install the bundle, drop a `florianv_swap.yaml` in `config/packages/`, and the `florianv_swap.swap` service is ready to inject. No service container plumbing, no boilerplate.**
+
+Symfony Swap is a drop-in package for **Symfony currency conversion**. Install it, configure providers in `config/packages/florianv_swap.yaml`, and pull **Symfony exchange rates** from multiple providers in one call. The bundle integrates with Symfony Cache out of the box and supports Symfony 6.4 / 7 / 8. Used in real-world Symfony applications since 2014.
+
+## 💡 What is Symfony Swap?
+
+- Symfony Swap is the Symfony integration of [Swap](https://github.com/florianv/swap), the PHP currency conversion library.
+- It registers a `florianv_swap.swap` service in the container (`Swap\Swap` class).
+- Configuration lives in `config/packages/florianv_swap.yaml`.
+- Caching uses Symfony Cache (`array`, `apcu`, `filesystem`, or any PSR-16 service ID).
+- Providers are tried in priority order (higher priority first).
+
+## 🎯 When should you use Symfony Swap?
+
+- Use Symfony Swap when you need exchange rates inside a Symfony application: localized prices, invoice totals, multi-currency reporting, historical FX data.
+- You do not need to install [Swap](https://github.com/florianv/swap) separately. It is pulled in as a dependency, and Symfony Swap exposes it through Symfony's container and cache.
+
+## 🧠 Why Symfony Swap and not raw Swap?
+
+Using [Swap](https://github.com/florianv/swap) directly inside a Symfony app means three pieces of plumbing on every project: registering the builder and the Swap service yourself, wiring Symfony Cache to the PSR-16 contract, and configuring providers in PHP rather than in the container. Doable, but boilerplate every project pays for.
+
+Symfony Swap does this for you:
+
+- **Drop-in.** Add the bundle to `config/bundles.php` and you are set.
+- **Symfony Cache integration.** Choose `array`, `apcu`, `filesystem`, or any PSR-16 service ID under `cache.type`.
+- **Container service.** `florianv_swap.swap` is ready to inject from any controller, service, or command.
+- **Configurable.** `config/packages/florianv_swap.yaml` exposes providers, options, and the cache.
+- **Priority-ordered providers.** Each provider has a `priority`; the bundle sorts them (higher priority tried first).
+
+If you are not on Symfony, use [Swap](https://github.com/florianv/swap) directly.
+
+## 📦 Installation
+
+Symfony Swap requires PHP 8.2 or newer and Symfony 6.4, 7, or 8.
 
 ```bash
-$ composer require florianv/swap-bundle php-http/message php-http/guzzle6-adapter ^1.0
+composer require florianv/swap-bundle symfony/http-client nyholm/psr7
 ```
 
-## Documentation
+Register the bundle in `config/bundles.php` (Symfony Flex skips this step if a recipe applies):
 
-The complete documentation can be found [here](https://github.com/florianv/symfony-swap/blob/master/Resources/doc/index.md).
+```php
+// config/bundles.php
+return [
+    // ...
+    Florianv\SwapBundle\FlorianvSwapBundle::class => ['all' => true],
+];
+```
 
-## Services
+Skip to [Quickstart](#-quickstart).
 
-Here is the list of the currently implemented services:
+---
 
-| Service | Base Currency | Quote Currency | Historical |
-|---------------------------------------------------------------------------|----------------------|----------------|----------------|
-| [Fixer](https://fixer.io/) | EUR (free, no SSL), * (paid) | * | Yes |
-| [Currency Data](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [Exchange Rates Data](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [Abstract](https://www.abstractapi.com) | * | * | Yes |
-| [coinlayer](https://coinlayer.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies) | Yes |
-| [Fixer](https://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
-| [currencylayer](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [exchangeratesapi](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [European Central Bank](https://www.ecb.europa.eu/home/html/index.en.html) | EUR | * | Yes |
-| [National Bank of Georgia](https://nbg.gov.ge) | * | GEL | Yes |
-| [National Bank of the Republic of Belarus](https://www.nbrb.by) | * | BYN (from 01-07-2016),<br>BYR (01-01-2000 - 30-06-2016),<br>BYB (25-05-1992 - 31-12-1999) | Yes |
-| [National Bank of Romania](http://www.bnr.ro) | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | Yes |
-| [National Bank of Ukranie](https://bank.gov.ua) | * | UAH | Yes |
-| [Central Bank of the Republic of Turkey](http://www.tcmb.gov.tr) | * | TRY | Yes |
-| [Central Bank of the Republic of Uzbekistan](https://cbu.uz) | * | UZS | Yes |
-| [Central Bank of the Czech Republic](https://www.cnb.cz) | * | CZK | Yes |
-| [Central Bank of Russia](https://cbr.ru) | * | RUB | Yes |
-| [Bulgarian National Bank](http://bnb.bg) | * | BGN | Yes |
-| [WebserviceX](http://www.webservicex.net) | * | * | No |
-| [1Forge](https://1forge.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Cryptonator](https://www.cryptonator.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies)  | No |
-| [CurrencyDataFeed](https://currencydatafeed.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |
-| [Xignite](https://www.xignite.com) | * | * | Yes |
-| [Currency Converter API](https://www.currencyconverterapi.com) | * | * | Yes (free but limited or paid) |
-| [xChangeApi.com](https://xchangeapi.com) | * | * | Yes |
-| [fastFOREX.io](https://www.fastforex.io) | USD (free), * (paid) | * | No |
-| [exchangerate.host](https://www.exchangerate.host) | * | * | Yes |
-| Array | * | * | Yes |
+_Optional: any PSR-18 HTTP client paired with a PSR-17 factory works. If your app already uses Guzzle, swap `symfony/http-client` for `php-http/guzzle7-adapter`. See the [documentation](Resources/doc/index.md) for alternatives._
 
-## Credits
+## ⚡ Quickstart
+
+Configure at least one provider in `config/packages/florianv_swap.yaml`. The European Central Bank works without an API key:
+
+```yaml
+# config/packages/florianv_swap.yaml
+florianv_swap:
+    providers:
+        european_central_bank:
+            priority: 0
+```
+
+Inject the service:
+
+```php
+use Swap\Swap;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class CurrencyController
+{
+    public function __construct(
+        #[Autowire(service: 'florianv_swap.swap')]
+        private readonly Swap $swap,
+    ) {}
+
+    public function rate(): array
+    {
+        // EUR → USD exchange rate
+        $rate = $this->swap->latest('EUR/USD');
+
+        return [
+            'value'    => $rate->getValue(),                 // e.g. 1.0823
+            'date'     => $rate->getDate()->format('Y-m-d'), // e.g. 2026-04-29
+            'provider' => $rate->getProviderName(),          // 'european_central_bank'
+        ];
+    }
+}
+```
+
+Or fetch directly from the container:
+
+```php
+$swap = $container->get('florianv_swap.swap');
+$rate = $swap->latest('EUR/USD');
+```
+
+Add commercial providers under `providers:` and they will be chained with the configured priority order:
+
+```yaml
+# config/packages/florianv_swap.yaml
+florianv_swap:
+    cache:
+        ttl: 3600
+        type: filesystem
+    providers:
+        apilayer_fixer:
+            api_key: '%env(SWAP_FIXER_KEY)%'
+            priority: 10                  # tried first
+        open_exchange_rates:
+            app_id: '%env(SWAP_OER_APP_ID)%'
+            priority: 5                   # tried second
+        european_central_bank:
+            priority: 0                   # free fallback for EUR-base pairs
+```
+
+Providers are tried in priority order (higher first). If a provider does not support the requested currency pair, it is skipped silently. If a provider throws an error, the next provider is tried. If every provider fails, a `ChainException` is thrown with all collected errors.
+
+## 💾 Caching
+
+Set `cache` in `config/packages/florianv_swap.yaml`:
+
+```yaml
+# config/packages/florianv_swap.yaml
+florianv_swap:
+    cache:
+        ttl: 3600
+        type: filesystem   # array, apcu, filesystem, or a PSR-16 service ID
+```
+
+For a custom cache, point `type` at any service implementing `Psr\SimpleCache\CacheInterface`:
+
+```yaml
+florianv_swap:
+    cache:
+        ttl: 3600
+        type: my_psr16_cache_service
+```
+
+Per-query overrides are documented in the [full documentation](Resources/doc/index.md#-caching).
+
+## 🛠 Common use cases
+
+- Display localized prices in multi-currency Symfony storefronts.
+- Compute invoice totals across currencies in a Symfony API.
+- Reconcile multi-currency ledgers using historical rates.
+- Power internal FX dashboards with rate history.
+- Build currency conversion infrastructure for Symfony-based fintech and ERP applications.
+
+## 🧭 Which package should I use?
+
+The Swap ecosystem is a layered toolkit for currency conversion in PHP:
+
+- **Swap.** The easy-to-use, high-level API for plain PHP.
+- **Exchanger.** Lower-level, more granular alternative; direct access to provider implementations.
+- **Laravel Swap.** Laravel application of Swap.
+- **Symfony Swap.** Symfony integration of Swap (this package).
+
+All four packages are MIT-licensed and require PHP 8.2 or newer.
+
+## 📚 Documentation
+
+The full documentation, with the per-provider configuration reference, custom service registration, cache types, and FAQ, is in [Resources/doc/index.md](Resources/doc/index.md). The full provider list with capabilities is in the [Swap README](https://github.com/florianv/swap#-providers).
+
+## 🧩 Related packages
+
+The Swap ecosystem:
+
+- [**Swap**](https://github.com/florianv/swap): easy-to-use PHP currency conversion library.
+- [**Exchanger**](https://github.com/florianv/exchanger): exchange rate provider layer.
+- [**Laravel Swap**](https://github.com/florianv/laravel-swap): Laravel application of Swap.
+- [**Symfony Swap**](https://github.com/florianv/symfony-swap): Symfony integration of Swap (this package).
+
+## 🤝 Sponsorship
+
+The Swap ecosystem is open to selected sponsorships from exchange rate API providers and financial infrastructure companies.
+
+Sponsorship can include:
+
+- Documentation visibility
+- Integration examples
+- Ecosystem-level visibility across Swap, Exchanger, Laravel Swap, and Symfony Swap
+
+For inquiries, contact the maintainer via [GitHub](https://github.com/florianv).
+
+## 🙌 Contributing
+
+Issues and pull requests are welcome. Please see the existing [issues](https://github.com/florianv/symfony-swap/issues) before opening a new one.
+
+## 📄 License
+
+The MIT License (MIT). Please see [LICENSE](LICENSE) for more information.
+
+## 👏 Credits
 
 - [Florian Voutzinos](https://github.com/florianv)
-- [All Contributors](https://github.com/florianv/symfony-swap/contributors)
-
-## License
-
-The MIT License (MIT). Please see [LICENSE](https://github.com/florianv/symfony-swap/blob/master/Resources/meta/LICENSE) for more information.
+- [All contributors](https://github.com/florianv/symfony-swap/contributors)

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -1,159 +1,377 @@
 # Documentation
 
-## Sponsors
+## 💡 What is Symfony Swap?
 
-<table>
-   <tr>
-      <td><img src="https://s3.amazonaws.com/swap.assets/fixer_icon.png?v=2" width="50px"/></td>
-      <td><a href="https://fixer.io">Fixer</a> is a simple and lightweight API for foreign exchange rates that supports up to 170 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://s3.amazonaws.com/swap.assets/currencylayer_icon.png" width="50px"/></td>
-     <td><a href="https://currencylayer.com">currencylayer</a> provides reliable exchange rates and currency conversions for your business up to 168 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://exchangeratesapi.io/assets/images/api-logo.svg" width="50px"/></td>
-     <td><a href="https://exchangeratesapi.io">exchangeratesapi</a> provides reliable exchange rates and currency conversions for your business with over 15 data sources.</td>
-   </tr>
-</table>
+- Symfony Swap is the Symfony integration of [Swap](https://github.com/florianv/swap), the PHP currency conversion library.
+- It registers a `florianv_swap.swap` service in the container (`Swap\Swap` class).
+- Configuration lives in `config/packages/florianv_swap.yaml`.
+- Caching uses Symfony Cache (`array`, `apcu`, `filesystem`, or any PSR-16 service ID).
+- Providers are tried in priority order (higher priority first).
+
+For the wider ecosystem (Swap, Exchanger, Laravel Swap), see the [README](../../README.md).
+
+## 🎯 When should you use Symfony Swap?
+
+- Use Symfony Swap when you need exchange rates inside a Symfony application: localized prices, invoice totals, multi-currency reporting, historical FX data.
+- You do not need to install [Swap](https://github.com/florianv/swap) separately. It is pulled in as a dependency, and Symfony Swap exposes it through Symfony's container and cache.
+
+## 🧠 Why Symfony Swap and not raw Swap?
+
+- **Drop-in.** Add the bundle to `config/bundles.php` and you are set.
+- **Symfony Cache integration.** Choose `array`, `apcu`, `filesystem`, or any PSR-16 service ID under `cache.type`.
+- **Container service.** `florianv_swap.swap` is ready to inject from any controller, service, or command.
+- **Configurable.** `config/packages/florianv_swap.yaml` exposes providers, options, and the cache.
+- **Priority-ordered providers.** Each provider has a `priority`; the bundle sorts them (higher priority tried first), unlike Swap and Laravel Swap, which use declaration order.
 
 ## Index
 
-* [Installation](#installation)
-* [Configuration](#configuration)
-  * [Services](#services)
-  * [Cache](#cache)
-    * [Lifetime](#lifetime)
-    * [Cache type](#cache-type)
-* [Usage](#usage)
+* [Installation](#-installation)
+* [Setup](#-setup)
+* [Configuration](#-configuration)
+  * [Config tree](#config-tree)
+  * [Provider configuration](#provider-configuration)
+  * [Cache configuration](#cache-configuration)
+* [Usage](#-usage)
+  * [Injecting the service](#injecting-the-service)
+  * [Latest and historical rates](#latest-and-historical-rates)
+  * [Inspecting the rate](#inspecting-the-rate)
+* [Per-query options](#-per-query-options)
+* [Creating a custom service](#-creating-a-custom-service)
+  * [Standard service](#standard-service)
+  * [Historical service](#historical-service)
+* [FAQ](#-faq)
 
-## Installation
+## 📦 Installation
+
+Symfony Swap requires PHP 8.2 or newer and Symfony 6.4, 7, or 8.
 
 ```bash
-composer require florianv/swap-bundle php-http/message php-http/guzzle6-adapter
+composer require florianv/swap-bundle symfony/http-client nyholm/psr7
 ```
 
-Enable the Bundle in the kernel:
+`symfony/http-client` is the PSR-18 HTTP client and `nyholm/psr7` provides the PSR-17 factories. Any PSR-18 / PSR-17 implementation works; for example, if your app already uses Guzzle:
 
-``` php
-<?php
-// app/AppKernel.php
+```bash
+composer require florianv/swap-bundle php-http/guzzle7-adapter nyholm/psr7
+```
 
-public function registerBundles()
+## ⚙ Setup
+
+Register the bundle in `config/bundles.php`:
+
+```php
+// config/bundles.php
+return [
+    // ...
+    Florianv\SwapBundle\FlorianvSwapBundle::class => ['all' => true],
+];
+```
+
+Create the configuration file at `config/packages/florianv_swap.yaml` (see [Configuration](#-configuration) below).
+
+## ⚙ Configuration
+
+### Config tree
+
+```yaml
+# config/packages/florianv_swap.yaml
+florianv_swap:
+    cache:
+        ttl: 3600
+        type: filesystem
+    providers:
+        european_central_bank:
+            priority: 0
+```
+
+At least one provider is required. Each provider accepts a `priority` integer (higher priority is tried first) and the provider-specific options listed below.
+
+### Provider configuration
+
+Public providers (central banks, national banks, `cryptonator`, `webservicex`) need only a `priority`:
+
+```yaml
+florianv_swap:
+    providers:
+        european_central_bank:
+            priority: 0
+        national_bank_of_romania:
+            priority: 0
+```
+
+Commercial providers require an API key. The option name varies by provider:
+
+| Identifier                       | Required option | Optional flags        |
+| -------------------------------- | --------------- | --------------------- |
+| `abstract_api`                   | `api_key`       |                       |
+| `apilayer_currency_data`         | `api_key`       |                       |
+| `apilayer_exchange_rates_data`   | `api_key`       |                       |
+| `apilayer_fixer`                 | `api_key`       |                       |
+| `coin_layer`                     | `access_key`    | `paid` (bool)         |
+| `currency_converter`             | `access_key`    | `enterprise` (bool)   |
+| `currency_data_feed`             | `api_key`       |                       |
+| `currency_layer`                 | `access_key`    | `enterprise` (bool)   |
+| `exchange_rates_api`             | `access_key`    |                       |
+| `fixer`                          | `access_key`    | `enterprise` (bool)   |
+| `forge`                          | `api_key`       |                       |
+| `open_exchange_rates`            | `app_id`        | `enterprise` (bool)   |
+| `xchangeapi`                     | `api-key`       | (note the hyphen)     |
+| `xignite`                        | `token`         |                       |
+
+Example:
+
+```yaml
+florianv_swap:
+    providers:
+        apilayer_fixer:
+            api_key: '%env(SWAP_FIXER_KEY)%'
+            priority: 10
+        open_exchange_rates:
+            app_id: '%env(SWAP_OER_APP_ID)%'
+            enterprise: false
+            priority: 5
+        european_central_bank:
+            priority: 0
+```
+
+The `array` provider is a special case used in tests and fixtures:
+
+```yaml
+florianv_swap:
+    providers:
+        array:
+            priority: 0
+            latestRates:
+                'EUR/USD': 1.1
+                'EUR/GBP': 1.5
+            historicalRates:
+                '2017-01-01':
+                    'EUR/USD': 1.5
+```
+
+The full provider list with capabilities (base currency, quote currency, historical support) is in the [Swap README's Providers table](https://github.com/florianv/swap#-providers).
+
+### Cache configuration
+
+```yaml
+florianv_swap:
+    cache:
+        ttl: 3600        # cache TTL in seconds
+        type: filesystem # array, apcu, filesystem, or a PSR-16 service ID
+```
+
+The bundle accepts these built-in `type` values:
+
+- `array`: in-memory `Symfony\Component\Cache\Adapter\ArrayAdapter`
+- `apcu`: `Symfony\Component\Cache\Adapter\ApcuAdapter`
+- `filesystem`: `Symfony\Component\Cache\Adapter\FilesystemAdapter`
+
+For any other PSR-16 cache, point `type` at a service ID:
+
+```yaml
+florianv_swap:
+    cache:
+        ttl: 3600
+        type: my_psr16_cache_service
+```
+
+The service must implement `Psr\SimpleCache\CacheInterface`.
+
+## ⚡ Usage
+
+### Injecting the service
+
+Inject `Swap\Swap` via the `florianv_swap.swap` service ID:
+
+```php
+use Swap\Swap;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class CurrencyController
 {
-    $bundles = array(
-        // ...
-        new Florianv\SwapBundle\FlorianvSwapBundle(),
-    );
+    public function __construct(
+        #[Autowire(service: 'florianv_swap.swap')]
+        private readonly Swap $swap,
+    ) {}
 }
 ```
 
-## Configuration
-
-### Services
-
-We recommend to use one of the [services that support our project](#sponsors), providing a free plan up to 1,000 requests per day.
-
-The complete list of all supported services is available here:
-
-```yaml
-# app/config/config.yml
-florianv_swap:
-    providers:
-        apilayer_fixer:
-            api_key: secret                # Get your key here: https://fixer.io/
-        apilayer_currency_data:            # Get your key here: https://currencylayer.com
-          api_key: secret
-        apilayer_exchange_rates_data:      # Get your key here: https://exchangeratesapi.io
-          api_key: secret   
-        abstract_api:                      # Get your key here: https://app.abstractapi.com/users/signup
-            api_key: secret     
-        webservicex: ~                     # WebserviceX
-        cryptonator: ~                     # Cryptonator
-        forge:                             # Forge
-           api_key: secret    
-        russian_central_bank: ~            # Russian Central Bank
-        european_central_bank: ~           # European Central Bank
-        national_bank_of_romania: ~        # National Bank of Romania
-        central_bank_of_czech_republic: ~  # Central Bank of the Czech Republic
-        central_bank_of_republic_turkey: ~ # Central Bank of the Republic of Turkey
-        open_exchange_rates:               # Open Exchange Rates
-            app_id: secret
-            enterprise: true
-        xignite:                           # Xignite
-            token: secret
-        currency_converter:                # Currency Converter API
-            access_key: secret
-            enterprise: true
-        xchangeapi:                        # xChangeApi.com
-           api-key: secret    
-        array:
-            latestRates:
-                    'EUR/GBP': 1.5
-                    'EUR/USD': 1.1
-            historicalRates:
-                    '2017-01-01':
-                        'EUR/GBP': 1.5
-                        'EUR/USD': 1.1
-```
-
-You can register multiple providers, they will be called in chain regarding to their priorities (higher first).
-In this example, Swap uses the [Fixer](http://fixer.io) service, and will fallback to [currencylayer](https://currencylayer.com) in case of failure.
-
-```yaml
-# app/config/config.yml
-florianv_swap:
-    providers:
-        apilayer_fixer:
-            api_key: secret
-            #priority: 0 (default)
-        apilayer_currency_data:                   
-            access_key: secret
-            priority: 1          
-```
-
-### Cache
-
-Currently only some of the [Symfony Cache](https://symfony.com/doc/current/components/cache.html#available-simple-cache-psr-16-classes) adapters are supported.
-
-#### Lifetime
-
-You must specify a lifetime for your cache entries:
-
-```yaml
-# app/config/config.yml
-florianv_swap:
-    cache:
-        ttl: 3600 # seconds
-```
-
-#### Cache type
-
-You can use a service id:
-
-```yaml
-# app/config/config.yml
-florianv_swap:
-    cache:
-        type: my_cache_service
-```
-
-or one of the implemented providers (`array`, `apcu`, `filesystem`)
-
-```yaml
-# app/config/config.yml
-florianv_swap:
-    cache:
-        type: apcu
-```
-
-## Usage
-
-The Swap service is available in the container:
+You can also fetch it from the container directly:
 
 ```php
-/** @var \Swap\Swap $swap */
-$swap = $this->get('florianv_swap.swap');
+$swap = $container->get('florianv_swap.swap');
 ```
 
-For more information about how to use it, please consult the [Swap documentation](https://github.com/florianv/swap).
+### Latest and historical rates
+
+```php
+$rate = $this->swap->latest('EUR/USD');
+
+echo $rate->getValue();                 // e.g. 1.0823
+echo $rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
+
+$rate = $this->swap->historical('EUR/USD', new \DateTime('-15 days'));
+```
+
+> Currencies are expressed as their [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code.
+
+### Inspecting the rate
+
+The returned `Exchanger\Contract\ExchangeRate` exposes:
+
+```php
+$rate->getValue();         // float
+$rate->getDate();          // DateTimeInterface
+$rate->getCurrencyPair();  // Exchanger\CurrencyPair
+$rate->getProviderName();  // string, the identifier that returned the rate
+```
+
+`getProviderName()` is useful when several providers are configured: the returned value is the identifier of the provider that actually answered, for example `european_central_bank`.
+
+## 💾 Per-query options
+
+Cache behavior can be overridden per call by passing an options array to `latest()` or `historical()`.
+
+| Option             | Type   | Default | Effect                                                                                                |
+| ------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
+| `cache_ttl`        | int    | `null`  | Cache TTL in seconds. `null` means entries do not expire.                                             |
+| `cache`            | bool   | `true`  | Set to `false` to bypass the cache for this call.                                                     |
+| `cache_key_prefix` | string | `""`    | Prefix for the cache key. Max 24 characters (PSR-6 limits keys to 64 chars; the internal hash takes 40). |
+
+PSR-6 does not allow the characters `{}()/\@:` in keys; Swap replaces them with `-`.
+
+```php
+$rate = $this->swap->latest('EUR/USD', ['cache' => false]);
+$rate = $this->swap->latest('EUR/USD', ['cache_ttl' => 60]);
+```
+
+## 🧩 Creating a custom service
+
+You can register your own provider by implementing the same contract used internally. If your service makes HTTP requests, extend `Exchanger\Service\HttpService`; otherwise extend `Exchanger\Service\Service`.
+
+### Standard service
+
+Create the service class:
+
+```php
+namespace App\Swap;
+
+use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\ExchangeRate;
+use Exchanger\Service\HttpService;
+
+class ConstantService extends HttpService
+{
+    public function getExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
+    {
+        // To call an HTTP endpoint:
+        // $content = $this->request('https://example.com');
+
+        return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
+    }
+
+    public function processOptions(array &$options): void
+    {
+        if (!isset($options['value'])) {
+            throw new \InvalidArgumentException('The "value" option must be provided.');
+        }
+    }
+
+    public function supportQuery(ExchangeRateQuery $exchangeQuery): bool
+    {
+        return 'EUR' === $exchangeQuery->getCurrencyPair()->getBaseCurrency();
+    }
+
+    public function getName(): string
+    {
+        return 'constant';
+    }
+}
+```
+
+Register it from a Symfony compiler pass or a kernel `boot()` method via `Swap\Service\Registry`:
+
+```php
+namespace App;
+
+use App\Swap\ConstantService;
+use Swap\Service\Registry;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+
+class Kernel extends BaseKernel
+{
+    public function boot(): void
+    {
+        parent::boot();
+
+        Registry::register('constant', ConstantService::class);
+    }
+}
+```
+
+Then use the identifier in `config/packages/florianv_swap.yaml`:
+
+```yaml
+florianv_swap:
+    providers:
+        constant:
+            priority: 0
+            value: 10
+```
+
+### Historical service
+
+To support historical rates, use the `SupportsHistoricalQueries` trait. Rename `getExchangeRate` to `getLatestExchangeRate` (now `protected`) and implement `getHistoricalExchangeRate`:
+
+```php
+use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\ExchangeRate;
+use Exchanger\HistoricalExchangeRateQuery;
+use Exchanger\Service\HttpService;
+use Exchanger\Service\SupportsHistoricalQueries;
+
+class ConstantService extends HttpService
+{
+    use SupportsHistoricalQueries;
+
+    protected function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
+    {
+        return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
+    }
+
+    protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery): ExchangeRate
+    {
+        return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
+    }
+}
+```
+
+## ❓ FAQ
+
+#### What happens when every provider fails?
+
+Swap throws an `Exchanger\Exception\ChainException`. Calling `$exception->getExceptions()` on it returns the list of exceptions collected from each provider in the chain.
+
+#### Can I use Symfony Swap without an API key?
+
+Yes. The European Central Bank, the national banks, `cryptonator`, and `webservicex` do not require an API key. See the [Swap README's Providers table](https://github.com/florianv/swap#-providers) for the full list.
+
+#### How does Symfony Swap relate to Swap?
+
+Symfony Swap is the Symfony integration of Swap. It pulls Swap in as a dependency and exposes it through Symfony's container and cache. If you are not on Symfony, use [Swap](https://github.com/florianv/swap) directly.
+
+#### How do I cache rates?
+
+Set `cache.type` in `config/packages/florianv_swap.yaml` to one of `array`, `apcu`, `filesystem`, or a PSR-16 service ID. See [Cache configuration](#cache-configuration).
+
+#### How do I disable cache for a single query?
+
+Pass `['cache' => false]` as the options argument: `$this->swap->latest('EUR/USD', ['cache' => false])`.
+
+#### How do I add my own provider?
+
+Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), register it from your `Kernel::boot()` with `Swap\Service\Registry::register()`, then reference its identifier in `config/packages/florianv_swap.yaml`. See [Creating a custom service](#-creating-a-custom-service).
+
+#### Where is the full provider list with capabilities?
+
+In the [Swap README's Providers table](https://github.com/florianv/swap#-providers). It lists every supported identifier with its base currency, quote currency, and historical support.

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,18 @@
 {
     "name": "florianv/swap-bundle",
     "type": "symfony-bundle",
-    "description": "Integrates the Swap library with Symfony",
+    "description": "Drop-in Symfony bundle for currency conversion: configurable services, multi-provider exchange rates with fallback and caching.",
     "keywords": [
-        "money",
-        "currency",
-        "conversion",
-        "rate",
-        "exchange",
+        "php",
         "symfony",
-        "bundle"
+        "symfony-bundle",
+        "currency-conversion",
+        "exchange-rates",
+        "exchange-rate-api",
+        "swap",
+        "money"
     ],
-    "homepage": "https://github.com/florianv/FlorianvSwapBundle",
+    "homepage": "https://github.com/florianv/symfony-swap",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
## What changed

### README

- Rewrote around a 'plug-and-play Symfony' value proposition: drop-in bundle for currency conversion, configurable via ``config/packages/florianv_swap.yaml``, container service ready to inject as ``Swap\Swap``.
- New orientation sections (*What is Symfony Swap?*, *When should you use Symfony Swap?*, *Why Symfony Swap and not raw Swap?*, *Common use cases*, *Which package should I use?*), aligned with the rest of the ecosystem.
- Modernized the install path: PSR-18 first via ``symfony/http-client``; the EOL ``php-http/guzzle6-adapter`` mention is gone.
- Modernized the registration path: register the bundle in ``config/bundles.php`` (Symfony 4+/5+/6+/7+/8+) instead of the pre-Symfony 4 AppKernel pattern.
- Replaced the APILayer-anchored quickstart with a neutral default (``european_central_bank``, free, no API key) and a fallback-chain example using priorities.
- Dropped the duplicated Services table that mirrored the Swap README. The README now points to the canonical [Swap Providers table](https://github.com/florianv/swap#-providers).
- Added cross-links to Swap, Exchanger, and Laravel Swap.
- Added a neutral Sponsorship section near the bottom.
- Added light section emojis for visual scanning.
- Dropped the legacy s3 logo image from the H1 for a cleaner header.

### ``Resources/doc/index.md``

- Dropped the legacy ``## Sponsors`` block at the top and the *'we recommend the services that support our project'* line in Configuration. No commercial provider is preferred.
- Added the same orientation sections at the top so the doc stands on its own and aligns vocabulary with the README.
- Modernized Installation (PSR-18 first, Guzzle 7 alternative noted; ``guzzle6-adapter`` removed).
- Modernized Setup to ``config/bundles.php`` and ``config/packages/``.
- Added a *Provider configuration* table mapping each commercial identifier to its required option (``api_key``, ``access_key``, ``app_id``, ``token``, ``api-key``) and optional flags (``enterprise``, ``paid``). Public providers and the ``array`` fixture are documented separately.
- Added a *Cache configuration* subsection covering the built-in ``array`` / ``apcu`` / ``filesystem`` types and PSR-16 service ID injection.
- Updated Usage to modern Symfony patterns (constructor injection with ``#[Autowire(service: 'florianv_swap.swap')]``) plus the container-fetch fallback.
- Added a *Per-query options* table.
- Replaced the legacy *Supported Services* code dump with a pointer to the [Swap README Providers table](https://github.com/florianv/swap#-providers).
- Added a short FAQ at the end.

### ``composer.json``

- Updated description and Packagist keywords for discoverability.
- Fixed the ``homepage`` field, which still pointed at the old ``FlorianvSwapBundle`` URL.

### ``LICENSE``

- Added a top-level ``LICENSE`` file (MIT) so GitHub detects the license on the repository sidebar (the existing ``Resources/meta/LICENSE`` was not picked up by the GitHub license detector). Copyright range refreshed to 2014-2026.

## Why

- A new Symfony developer running ``composer require florianv/swap-bundle``, registering the bundle, and dropping a ``florianv_swap.yaml`` immediately gets a working ``Swap\Swap`` injection, with no commercial-API friction.
- High-intent terms (Symfony currency conversion, Symfony exchange rates, drop-in bundle, container service, ``config/packages``) are now in headings, the opening paragraph, and the Packagist metadata.
- The README is a value-proposition page, not a duplicate of the Swap README. The Providers table lives in one place.
- GitHub now recognizes the MIT license on the repository, restoring a trust signal that was missing.

## What did NOT change

- No runtime code changes. Public API of ``Florianv\SwapBundle\FlorianvSwapBundle``, ``FlorianvSwapExtension``, and the ``florianv_swap.swap`` / ``florianv_swap.builder`` container service IDs is unchanged.
- No changes to ``DependencyInjection/``, ``Resources/config/``, ``Tests/``, CI, Psalm config, or php-cs-fixer config.
- The ``Resources/meta/LICENSE`` file is kept for backward compatibility; the new top-level ``LICENSE`` is what GitHub now reads.
- The CHANGELOG was not touched (this is doc work, not a release).