### PR TITLE
docs: express provider count as 30+

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Per-query overrides are documented in the [full documentation](Resources/doc/ind
 
 ## 📊 Providers
 
-Symfony Swap supports the 30 exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `providers` in `config/packages/florianv_swap.yaml`.
+Symfony Swap supports the 30+ exchange rate providers from the underlying [Swap](https://github.com/florianv/swap) library. Pass the **identifier** as the key under `providers` in `config/packages/florianv_swap.yaml`.
 
 ### Commercial providers (require an API key)
 


### PR DESCRIPTION
Words the provider count as `30+` instead of a hardcoded exact number, so it stays correct as the underlying Swap provider list grows (no recurring docs edit). Also corrects the current stale `30` (Swap now ships more).

### Changes

- **README.md** — provider configuration section now reads `30+` instead of `30`.

Docs only.